### PR TITLE
Fix for spamBlocker.refreshPiwikReferrers

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ module.exports.refreshPiwikReferrers = function(next) {
 					spamReferrers: referrers
 				};
 
-				fs.writeFile(__dirname . '/lib/piwik.spam.json', JSON.stringify(spam, null, 4), function(err) {
+				fs.writeFile(__dirname + '/lib/piwik.spam.json', JSON.stringify(spam, null, 4), function(err) {
 					if (err) {
 						console.error(err);
 						next(false);

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ module.exports.refreshPiwikReferrers = function(next) {
 					spamReferrers: referrers
 				};
 
-				fs.writeFile('./lib/piwik.spam.json', JSON.stringify(spam, null, 4), function(err) {
+				fs.writeFile(__dirname . '/lib/piwik.spam.json', JSON.stringify(spam, null, 4), function(err) {
 					if (err) {
 						console.error(err);
 						next(false);


### PR DESCRIPTION
Hi,

this allow to use **refreshPiwikReferrers** from outside, like : 

```
spamBlocker.refreshPiwikReferrers(function(success){
    if (success) {
        console.log("Updated SPAM Referrers");
    } else {
        console.log("Failed to update SPAM Referrers");
    }
    app.use(spamBlocker.send404);
});
```
